### PR TITLE
Add multi-class classification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Repository with basic machine learning algorithms implemented in PyTorch.
 The coffea files used as inputs are based on the output of [PocketCoffea](https://github.com/PocketCoffea/PocketCoffea/tree/main). In particular, the framework was developed based on the output of the
 [AnalysisConfigs](https://github.com/matteomalucchi/AnalysisConfigs) repository, which is a collection of analysis configurations for the PocketCoffea framework.
 
+The framework supports both **binary classification** (signal vs background) and **multi-class classification** with an arbitrary number of classes — see [Configuration files](#configuration-files) below.
+
 ## Installation
 
 To create the micromamba environment, you can use the following command:
@@ -39,6 +41,216 @@ To execute an example training, evaluate the model on the test set, plot the his
 ml_train  -c configs/example_DNN_config_ggF_VBF.yml
 ```
 
+## Repository layout
+
+```
+ml_pytorch/
+├── defaults/                # default config, input-variable lists, preprocessing fns
+│   ├── default_configs.yml
+│   └── sig_bkg_dnn_input_variables.py, ...
+├── models/                  # DNN architectures (importable by name from configs)
+│   ├── DNN_model.py                       # binary, 1-node sigmoid + BCELoss
+│   ├── DNN_softmax_reweight_model.py      # binary, 2-node softmax + CrossEntropy
+│   ├── DNN_sigmoid_reweight_model.py      # binary, sigmoid w/ batchnorm + dropout
+│   └── DNN_multiclass_model.py            # multi-class, num_classes-node softmax
+├── scripts/                 # console entry points (train, sig_bkg_eval, plot_history, ...)
+└── utils/                   # dataset loader, training loop, learning-rate schedules
+configs/                     # YAML configuration files grouped by use case
+```
+
+## Configuration files
+
+Configurations are YAML files consumed by `ml_train`. Examples live under `configs/`. The framework supports **two layouts** for declaring training samples; the dataset loader auto-detects which is in use.
+
+### Binary (legacy) layout
+
+Use this when you have exactly two classes (signal vs background):
+
+```yaml
+signal_sample:    [GluGlutoHHto4B_spanet_skimmed]
+signal_dataset:   [GluGlutoHHto4B_spanet_kl-1p00_kt-1p00_c2-0p00_2022_postEE]
+signal_region:    [4b_signal_region]
+
+background_sample:  [DATA_JetMET_JMENano_E_skimmed, DATA_JetMET_JMENano_F_skimmed]
+background_dataset: [DATA_JetMET_JMENano_E_2022_postEE_EraE, DATA_JetMET_JMENano_F_2022_postEE_EraF]
+background_region:  [2b_signal_region_postW]
+
+input_variables: sig_bkg_dnn_input_variables   # module name in ml_pytorch/defaults/
+ML_model: DNN_softmax_reweight_model           # module name in ml_pytorch/models/
+data_format: coffea                            # one of: coffea, parquet, root
+data_dirs: [/path/to/coffea/output/]
+
+batch_size: 512
+epochs: 50
+learning_rate: 1e-3
+learning_rate_schedule: e5_drop75              # see ml_pytorch/utils/learning_rate_schedules.py
+
+train_fraction: 0.7
+val_fraction: 0.2
+test_fraction: 0.1
+
+early_stopping: True
+patience: 5
+min_delta: 1e-5
+eval_param: "loss"                             # or "acc"
+```
+
+Internally background is mapped to class index `0` and signal to class index `1`, matching the previous behaviour of all existing configs and saved models.
+
+### Multi-class layout
+
+For three or more classes, replace the `signal_*` / `background_*` blocks with a `classes` mapping. Each entry becomes one output node:
+
+```yaml
+input_variables: sig_bkg_dnn_input_variables
+ML_model: DNN_multiclass_model
+data_format: coffea
+data_dirs: [/path/to/coffea/output/]
+
+classes:
+  background:
+    sample:  [DATA_JetMET_JMENano_E_skimmed, DATA_JetMET_JMENano_F_skimmed, DATA_JetMET_JMENano_G_skimmed]
+    region:  [2b_signal_region_postW]
+    dataset: [DATA_JetMET_JMENano_E_2022_postEE_EraE, DATA_JetMET_JMENano_F_2022_postEE_EraF, DATA_JetMET_JMENano_G_2022_postEE_EraG]
+    lbl: 0
+  ggF_HH:
+    sample:  [GluGlutoHHto4B_spanet_skimmed]
+    region:  [4b_signal_region]
+    dataset: [GluGlutoHHto4B_spanet_kl-1p00_kt-1p00_c2-0p00_2022_postEE]
+    lbl: 1
+  VBF_HH:
+    sample:  [VBF_HHto4B]
+    region:  [4b_signal_region]
+    dataset: [VBFHHto4B_CV_1_C2V_1_C3_1_2022_postEE]
+    lbl: 2
+
+batch_size: 512
+epochs: 50
+learning_rate: 1e-3
+learning_rate_schedule: e5_drop75
+train_fraction: 0.7
+val_fraction: 0.2
+test_fraction: 0.1
+```
+
+Notes on the `classes` block:
+
+* Each class needs `sample`, `region`, `dataset` (same semantics as the legacy keys) and a `lbl` integer.
+* Classes are ordered by ascending `lbl`, and that order becomes the **internal class index** (`0..C-1`) used both as the `CrossEntropyLoss` target and as the value stored in the saved score arrays. The user-provided `lbl` is kept as a label/identifier and shown in plot legends (`"className (lbl=...)"`).
+* `num_classes` is derived from the size of the block, so adding a class is purely a config change provided the model accepts a `num_classes` argument (see below).
+* `undersample`, `oversample_split` and `split_oversample` are signal-vs-background concepts and are only supported when there are exactly two classes.
+
+A ready-to-edit multi-class example is provided at `configs/hh4b_sig_bkg_classifier/example_DNN_config_multiclass.yml`.
+
+### Other useful config keys
+
+| key | meaning |
+|---|---|
+| `input_variables` | either a list of branch names or the name of a module in `ml_pytorch/defaults/` providing a `dnn_input_variables` `OrderedDict` |
+| `preprocess_variables_functions` | mapping `{var: [func_name, [args...]]}` resolved against `ml_pytorch/defaults/preprocess_variables_functions.py` |
+| `data_format` | `coffea`, `parquet`, or `root` |
+| `data_dirs` | list of directories containing the input files (`.coffea` files / parquet config) |
+| `oversample_split`, `split_oversample`, `undersample` | binary-only class balancing strategies |
+| `eval`, `roc`, `histos`, `history`, `onnx` | toggle the post-training outputs |
+| `gpus` | comma-separated GPU indices, or unset for CPU |
+| `seed` | seed for both event shuffling and weight initialisation |
+
+The default values used when a key is omitted are listed in `ml_pytorch/defaults/default_configs.yml`.
+
+## DNN architecture files
+
+Models live in `ml_pytorch/models/` and are referenced by the `ML_model` key in the YAML config (the filename without `.py`). Each file must expose:
+
+* a `torch.nn.Module` subclass implementing `forward`;
+* a top-level `get_model(...)` factory returning `(model, loss_fn, optimizer, scheduler)`;
+* optionally an `export_model(model)` method on the module that wraps the network for ONNX export (e.g. to apply a softmax inside the exported graph).
+
+### Binary models — legacy signature
+
+Binary models (1-node sigmoid + `BCELoss`, or 2-node softmax + `CrossEntropyLoss`) keep the original `get_model` signature:
+
+```python
+def get_model(input_size, device, lr, lr_schedule, n_epochs):
+    model = DNN(input_size).to(device)
+    loss_fn = torch.nn.CrossEntropyLoss(reduction="none")  # or BCELoss for 1 node
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    scheduler = get_lr_scheduler(lr_schedule, optimizer, n_epochs)
+    return model, loss_fn, optimizer, scheduler
+```
+
+You can use any of these models with the binary (legacy) config layout — see `DNN_model.py`, `DNN_softmax_reweight_model.py`, `DNN_sigmoid_reweight_model.py` and variants.
+
+### Multi-class models — `num_classes` signature
+
+A multi-class model must accept an extra `num_classes` parameter so the size of the output layer can be driven by the YAML. `ml_pytorch/scripts/train.py` introspects the function signature and dispatches automatically: a model with `num_classes` in its signature gets `num_classes` passed in, a legacy binary model does not.
+
+A minimal example (`ml_pytorch/models/DNN_multiclass_model.py`) is provided:
+
+```python
+from torch import nn
+import torch
+
+from ml_pytorch.utils.learning_rate_schedules import get_lr_scheduler
+
+
+class DNN(nn.Module):
+    def __init__(self, dim_in: int, num_classes: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim_in, 64), nn.ReLU(), nn.Dropout(0.2),
+            nn.Linear(64, 64),     nn.ReLU(), nn.Dropout(0.2),
+            nn.Linear(64, 64),     nn.ReLU(), nn.Dropout(0.2),
+            nn.Linear(64, num_classes),       # multi-class logits
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+    def export_model(self, model):
+        # ONNX wrapper that applies softmax inside the graph
+        class ONNXWrappedModel(torch.nn.Module):
+            def __init__(self, m):
+                super().__init__()
+                self.m = m
+            def forward(self, x):
+                return torch.nn.functional.softmax(self.m(x), dim=1)
+        return ONNXWrappedModel(model)
+
+
+def get_model(input_size, num_classes, device, lr, lr_schedule, n_epochs):
+    model = DNN(input_size, num_classes).to(device)
+    # raw logits + CrossEntropyLoss for single-label multi-class
+    loss_fn = torch.nn.CrossEntropyLoss(reduction="none")
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = get_lr_scheduler(lr_schedule, optimizer, n_epochs)
+    return model, loss_fn, optimizer, scheduler
+```
+
+To create your own architecture:
+
+1. Add a new file in `ml_pytorch/models/`, e.g. `DNN_my_model.py`.
+2. Define a `torch.nn.Module` whose `__init__` takes `dim_in` (and `num_classes` if multi-class).
+3. Define `get_model(input_size, [num_classes,] device, lr, lr_schedule, n_epochs)` returning `(model, loss_fn, optimizer, scheduler)`. Use `reduction="none"` on the loss — the training loop applies per-event weights manually.
+4. Reference the file (without `.py`) from your config: `ML_model: DNN_my_model`.
+
+When using a legacy binary model with a multi-class config (`num_classes > 2`), `ml_train` raises an explicit error and points you at `DNN_multiclass_model`.
+
+## Input variable files
+
+Lists of input branches live in `ml_pytorch/defaults/`, each exposing a `dnn_input_variables` `OrderedDict` mapping output column name → `[collection, leaf]`. Reference them from a config either as a literal list of branch names:
+
+```yaml
+input_variables: [JetGood_pt, JetGood_eta, JetGood_phi, JetGood_mass, JetGood_btagPNetB]
+```
+
+or as the name of a module under `ml_pytorch/defaults/`:
+
+```yaml
+input_variables: sig_bkg_dnn_input_variables
+```
+
+In the second form the columns are resolved via `create_DNN_columns_list(run2, dnn_input_variables)` in `ml_pytorch/utils/tools.py`, which also handles the `Run2` branch-name suffix when the config sets `run2: True`.
+
 ## Training on a cluster with slurm
 
 To execute either a 20x training for background reweighting or to run a `sig_bkg_classifier` model, there are two scripts that can be run with slurm:
@@ -66,6 +278,20 @@ To execute 5 runs in a node without the interactive access to the GPU node (the 
 sbatch --account gpu_gres --job-name "InteractiveJob" --cpus-per-task 4 --mem-per-cpu 5000 --time 12:00:00  -p gpu --gres=gpu:1 --wrap=". ./run_batch_of_5.sh /work/tharte/datasets/ML_pytorch/configs/bkg_reweighting/DNN_AN_1e-3_e20drop75_minDelta1em5_SPANet_postEE.yml out/bkg_reweighting/SPANET_ptFlat_20_runs_postEE 0"
 ```
 
+## Outputs of a training
+
+Each training run writes to `${output_dir}` (default `/work/$USER/out_ML_pytorch/<config_name>/`):
+
+* `config_parameters.yml` — full resolved config (defaults + CLI + YAML) snapshot.
+* `ML_model.py` — copy of the model file used, so a saved run can be re-loaded with `-l`/`--load-model` even after the file in `ml_pytorch/models/` changes.
+* `logger_<name>.log` — training log with epoch-by-epoch loss / accuracy / learning rate.
+* `state_dict/model_<epoch>_state_dict.pt` — best-epoch checkpoint(s).
+* `state_dict/model_best_epoch_<n>.onnx` — ONNX export of the best model (and one for the last epoch).
+* `score_lbl_array.npz` — saved with `--save-numpy`. Contains:
+  * `score_lbl_array_train`, `score_lbl_array_test`: `[scores..., label, weight, kl]` per event. For binary the score block is a single column, for multi-class it has `num_classes` columns.
+  * `train_test_fractions`, `num_classes`, `class_info` (list of `{name, lbl, class_idx}` dicts).
+* Plots: `sig_bkg_distributions_*`, `roc_curve_*`, training history, etc.
+
 ## Additional scripts
 
 The training will produce the ONNX model to be used in PocketCoffea for background morphing, as well as plots with the training history, the ROC curve and an overtraining check.
@@ -73,12 +299,23 @@ The training will produce the ONNX model to be used in PocketCoffea for backgrou
 These plots can be produced using the following command:
 
 ```bash
-# Plot the history of a training 
+# Plot the history of a training
 ml_history -i <training_log_file>
 
 # Plot the ROC curve and overtraining check
 ml_sb -i <training_directory>
 ```
+
+### Multi-class evaluation outputs
+
+When `ml_sb` (the `sig_bkg_eval` script) detects more than one score column in `score_lbl_array.npz`, it automatically switches to multi-class mode and produces:
+
+* `roc_curve_one_vs_rest.{png,pdf}` — for each class *i*, the ROC of "is class *i*" using the score of output node *i*.
+* `roc_curve_one_vs_one.{png,pdf}` — for each ordered pair `(a, b)`, the ROC of "class *a* vs class *b*" using events with true label `∈ {a, b}` and the score of node *a*.
+* `score_distribution_class_<i>.{png,pdf}` (+ `_log`) — distribution of output node *i*'s score, split by true class, for train and test.
+* `tpr_fpr_multiclass.npz` — the saved (`tpr`, `fpr`, `auc`) arrays so that arbitrary class combinations can be replotted later.
+
+The binary path (single score column) is unchanged and still produces `sig_bkg_distributions_kl_*` and `roc_curve_kl_*`.
 
 ## COMET integration
 

--- a/configs/hh4b_sig_bkg_classifier/example_DNN_config_multiclass.yml
+++ b/configs/hh4b_sig_bkg_classifier/example_DNN_config_multiclass.yml
@@ -1,0 +1,65 @@
+# Example configuration for a multi-class classifier.
+#
+# The legacy binary layout (``signal_dataset``, ``background_dataset``, ...)
+# is still supported. To define more than two classes, use the ``classes``
+# block instead: each child becomes one output node, ordered by ``lbl``.
+
+input_variables: sig_bkg_dnn_input_variables
+
+run2: False
+
+classes:
+  background:
+    sample:
+      [
+        DATA_JetMET_JMENano_E_skimmed,
+        DATA_JetMET_JMENano_F_skimmed,
+        DATA_JetMET_JMENano_G_skimmed,
+      ]
+    region: [2b_signal_region_postW]
+    dataset:
+      [
+        DATA_JetMET_JMENano_E_2022_postEE_EraE,
+        DATA_JetMET_JMENano_F_2022_postEE_EraF,
+        DATA_JetMET_JMENano_G_2022_postEE_EraG,
+      ]
+    lbl: 0
+  ggF_HH:
+    sample: [GluGlutoHHto4B_spanet_skimmed]
+    region: [4b_signal_region]
+    dataset:
+      [
+        GluGlutoHHto4B_spanet_kl-1p00_kt-1p00_c2-0p00_2022_postEE,
+        GluGlutoHHto4B_spanet_kl-0p50_kt-1p00_c2-0p00_2022_postEE,
+      ]
+    lbl: 1
+  VBF_HH:
+    sample: [VBF_HHto4B]
+    region: [4b_signal_region]
+    dataset: [VBFHHto4B_CV_1_C2V_1_C3_1_2022_postEE]
+    lbl: 2
+
+ML_model: DNN_multiclass_model
+
+data_format: coffea
+
+batch_size: 512
+epochs: 50
+
+learning_rate: 1e-3
+learning_rate_schedule: e5_drop75
+
+early_stopping: True
+patience: 5
+min_delta: 1e-5
+
+eval_param: "loss"
+
+train_fraction: 0.7
+val_fraction: 0.2
+test_fraction: 0.1
+
+data_dirs:
+  [
+    /work/mmalucch/out_hh4b/out_MC_DATA_spanet_ptflat_btag5WP_BkgMorphing/,
+  ]

--- a/ml_pytorch/models/DNN_multiclass_model.py
+++ b/ml_pytorch/models/DNN_multiclass_model.py
@@ -1,0 +1,50 @@
+from torch import nn
+import torch
+
+from ml_pytorch.utils.learning_rate_schedules import get_lr_scheduler
+
+
+class DNN(nn.Module):
+    def __init__(self, dim_in: int, num_classes: int):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Linear(dim_in, 64),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(64, 64),
+            nn.ReLU(),
+            nn.Dropout(0.2),
+            nn.Linear(64, num_classes),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+    def export_model(self, model):
+        class ONNXWrappedModel(torch.nn.Module):
+            def __init__(self, original_model):
+                super().__init__()
+                self.model = original_model
+
+            def forward(self, x):
+                logits = self.model(x)
+                return torch.nn.functional.softmax(logits, dim=1)
+
+        return ONNXWrappedModel(model)
+
+
+def get_model(input_size, num_classes, device, lr, lr_schedule, n_epochs):
+    model = DNN(input_size, num_classes).to(device)
+    print(model)
+
+    # Multi-class single-label classification:
+    #   model outputs raw logits [N, C]
+    #   targets are int64 class indices [N]
+    loss_fn = torch.nn.CrossEntropyLoss(reduction="none")
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr, weight_decay=1e-4)
+    scheduler = get_lr_scheduler(lr_schedule, optimizer, n_epochs)
+
+    return model, loss_fn, optimizer, scheduler

--- a/ml_pytorch/scripts/sig_bkg_eval.py
+++ b/ml_pytorch/scripts/sig_bkg_eval.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import argparse
+import itertools
 import numpy as np
 import mplhep as hep
 from scipy import stats
@@ -9,14 +10,42 @@ hep.style.use("CMS")
 hep.cms.label(loc=0)
 
 
-def handle_arrays(score_lbl_tensor, column=0):
-    sig = score_lbl_tensor[score_lbl_tensor[:, 1] == 1]
-    bkg = score_lbl_tensor[score_lbl_tensor[:, 1] == 0]
+def get_layout(score_lbl_tensor):
+    """Return ``(num_score_cols, label_col, weight_col, kl_col)``.
+
+    The score_lbl_array always stores ``[<scores...>, label, weight, kl]`` so
+    the trailing 3 columns are fixed and the number of leading score columns
+    depends on whether the model is binary (1 column) or multi-class
+    (``num_classes`` columns).
+    """
+    n_score = score_lbl_tensor.shape[1] - 3
+    return n_score, n_score, n_score + 1, n_score + 2
+
+
+def handle_arrays(score_lbl_tensor, column=0, sig_label=1, bkg_label=0):
+    """Backward-compatible binary helper: split into the (signal, background)
+    events using the label column derived from the array's layout."""
+    _, label_col, _, _ = get_layout(score_lbl_tensor)
+    sig = score_lbl_tensor[score_lbl_tensor[:, label_col] == sig_label]
+    bkg = score_lbl_tensor[score_lbl_tensor[:, label_col] == bkg_label]
 
     sig_value = sig[:, column]
     bkg_value = bkg[:, column]
 
     return sig_value, bkg_value
+
+
+def _class_label(class_info, class_idx, fallback=None):
+    """Lookup a human-readable name for ``class_idx`` from the class metadata
+    saved at training time. Falls back to a generic name when missing."""
+    if class_info is not None:
+        for c in class_info:
+            ci = c["class_idx"] if isinstance(c, dict) else c.class_idx
+            if int(ci) == int(class_idx):
+                name = c["name"] if isinstance(c, dict) else c.name
+                lbl = c["lbl"] if isinstance(c, dict) else c.lbl
+                return f"{name} (lbl={lbl})"
+    return fallback if fallback is not None else f"class {class_idx}"
 
 
 def my_roc_auc(
@@ -141,7 +170,22 @@ def plot_sig_bkg_distributions(
     signal_eff=0.2,
     get_max_significance=False,
     comet_logger=None,
+    class_info=None,
 ):
+    # Dispatch to the multi-class variant when the output has more than one
+    # score column (i.e. C >= 3 class probabilities are stored).
+    n_score, _, _, _ = get_layout(score_lbl_tensor_test)
+    if n_score > 1:
+        plot_multiclass_distributions(
+            score_lbl_tensor_train,
+            score_lbl_tensor_test,
+            dir,
+            show,
+            class_info,
+            comet_logger=comet_logger,
+        )
+        return
+
     # plot the signal and background distributions
     sig_score_train, bkg_score_train = handle_arrays(score_lbl_tensor_train, 0)
     sig_score_test, bkg_score_test = handle_arrays(score_lbl_tensor_test, 0)
@@ -152,9 +196,14 @@ def plot_sig_bkg_distributions(
     print("bkg_score_test",bkg_score_test, bkg_score_test.shape)
     
     # get weights
+    _, _, weight_col, kl_col = get_layout(score_lbl_tensor_test)
     try:
-        sig_weight_train, bkg_weight_train = handle_arrays(score_lbl_tensor_train, 2)
-        sig_weight_test, bkg_weight_test = handle_arrays(score_lbl_tensor_test, 2)
+        sig_weight_train, bkg_weight_train = handle_arrays(
+            score_lbl_tensor_train, weight_col
+        )
+        sig_weight_test, bkg_weight_test = handle_arrays(
+            score_lbl_tensor_test, weight_col
+        )
     except IndexError:
         print("WARNING: No weights found in the input file. Using equal weights.")
         sig_weight_train = np.ones_like(sig_score_train)
@@ -169,8 +218,8 @@ def plot_sig_bkg_distributions(
     
     # get the kl values
     try:
-        sig_kl_train, bkg_kl_train = handle_arrays(score_lbl_tensor_train, 3)
-        sig_kl_test, bkg_kl_test = handle_arrays(score_lbl_tensor_test, 3)
+        sig_kl_train, bkg_kl_train = handle_arrays(score_lbl_tensor_train, kl_col)
+        sig_kl_test, bkg_kl_test = handle_arrays(score_lbl_tensor_test, kl_col)
     except IndexError:
         print("WARNING: No kl values found in the input file. Using equal weights.")
         sig_kl_train = np.ones_like(sig_score_train) * 9999.
@@ -531,24 +580,34 @@ def plot_sig_bkg_distributions(
         plt.close(fig)
 
 
-def plot_roc_curve(score_lbl_tensor_test, dir, show, comet_logger=None):
+def plot_roc_curve(score_lbl_tensor_test, dir, show, comet_logger=None, class_info=None):
+    # Dispatch to multi-class ROCs when more than one score column is stored.
+    n_score, label_col, weight_col, kl_col = get_layout(score_lbl_tensor_test)
+    if n_score > 1:
+        plot_multiclass_roc_curves(
+            score_lbl_tensor_test, dir, show, class_info, comet_logger=comet_logger
+        )
+        return
+
     sig_score_test, bkg_score_test = handle_arrays(score_lbl_tensor_test, 0)
-    sig_lbl_test, bkg_lbl_test = handle_arrays(score_lbl_tensor_test, 1)
-    
+    sig_lbl_test, bkg_lbl_test = handle_arrays(score_lbl_tensor_test, label_col)
+
     # get the weight
     try:
-        sig_weight_test, bkg_weight_test = handle_arrays(score_lbl_tensor_test, 2)
+        sig_weight_test, bkg_weight_test = handle_arrays(
+            score_lbl_tensor_test, weight_col
+        )
     except IndexError:
         print("WARNING: No weight values found in the input file. Using equal weight.")
         sig_weight_test = np.ones_like(sig_score_test)
         bkg_weight_test = np.ones_like(bkg_score_test)
-    
+
     print("sig_weight_test",sig_weight_test, sig_weight_test.shape)
     print("bkg_weight_test",bkg_weight_test, bkg_weight_test.shape)
-    
+
     # get the kl values
     try:
-        sig_kl_test, bkg_kl_test = handle_arrays(score_lbl_tensor_test, 3)
+        sig_kl_test, bkg_kl_test = handle_arrays(score_lbl_tensor_test, kl_col)
     except IndexError:
         print("WARNING: No kl values found in the input file. Using equal weights.")
         sig_kl_test = np.ones_like(sig_score_test) * 9999.
@@ -648,6 +707,200 @@ def plot_roc_curve(score_lbl_tensor_test, dir, show, comet_logger=None):
     )
 
 
+def plot_multiclass_distributions(
+    score_lbl_tensor_train,
+    score_lbl_tensor_test,
+    dir,
+    show,
+    class_info=None,
+    comet_logger=None,
+):
+    """Plot, for each output node, the distribution of its score split by
+    true class. Produces ``score_distribution_class_<i>.png`` per output."""
+    n_score, label_col, weight_col, _ = get_layout(score_lbl_tensor_test)
+    train_labels = score_lbl_tensor_train[:, label_col].astype(int)
+    test_labels = score_lbl_tensor_test[:, label_col].astype(int)
+    train_weights = score_lbl_tensor_train[:, weight_col]
+    test_weights = score_lbl_tensor_test[:, weight_col]
+
+    true_classes = sorted(set(np.unique(train_labels)).union(np.unique(test_labels)))
+    print(f"Multi-class evaluation: output nodes = {n_score}, true classes = {true_classes}")
+
+    colors = plt.get_cmap("tab10").colors
+
+    for out_idx in range(n_score):
+        fig, ax = plt.subplots(figsize=[13, 9])
+        node_name = _class_label(class_info, out_idx, fallback=f"class {out_idx}")
+
+        train_scores = score_lbl_tensor_train[:, out_idx]
+        test_scores = score_lbl_tensor_test[:, out_idx]
+
+        for j, true_c in enumerate(true_classes):
+            color = colors[j % len(colors)]
+            tr_mask = train_labels == true_c
+            te_mask = test_labels == true_c
+            if tr_mask.sum() == 0 and te_mask.sum() == 0:
+                continue
+
+            label = _class_label(class_info, true_c, fallback=f"true class {true_c}")
+            ax.hist(
+                train_scores[tr_mask],
+                weights=train_weights[tr_mask],
+                bins=30,
+                range=(0, 1),
+                histtype="step",
+                density=True,
+                color=color,
+                linestyle="--",
+                label=f"{label} (train)",
+            )
+            ax.hist(
+                test_scores[te_mask],
+                weights=test_weights[te_mask],
+                bins=30,
+                range=(0, 1),
+                histtype="step",
+                density=True,
+                color=color,
+                linestyle="-",
+                label=f"{label} (test)",
+            )
+
+        ax.set_xlabel(f"Score of output node: {node_name}")
+        ax.set_ylabel("Normalized counts")
+        ax.legend(loc="upper center", fontsize=14, frameon=False)
+        ax.grid()
+        hep.cms.lumitext("2022 (13.6 TeV)", ax=ax)
+        hep.cms.text(text="Preliminary", ax=ax, loc=0)
+        if comet_logger:
+            comet_logger.log_figure(f"score_distribution_class_{out_idx}", plt)
+        plt.savefig(
+            f"{dir}/score_distribution_class_{out_idx}.png",
+            bbox_inches="tight",
+            dpi=300,
+        )
+        plt.savefig(
+            f"{dir}/score_distribution_class_{out_idx}.pdf",
+            bbox_inches="tight",
+            dpi=300,
+        )
+        ax.set_yscale("log")
+        plt.savefig(
+            f"{dir}/score_distribution_class_{out_idx}_log.png",
+            bbox_inches="tight",
+            dpi=300,
+        )
+        if show:
+            plt.show()
+        plt.close(fig)
+
+
+def plot_multiclass_roc_curves(
+    score_lbl_tensor_test, dir, show, class_info=None, comet_logger=None
+):
+    """Plot ROC curves for the multi-class output:
+
+    * One-vs-rest ROC for every output node (signal=node i, background=all
+      events whose true class != i, using score of node i).
+    * One-vs-one ROC for every ordered pair of classes (positive class A vs
+      negative class B, considering only events whose true class is A or B
+      and using score of node A).
+    """
+    n_score, label_col, weight_col, _ = get_layout(score_lbl_tensor_test)
+    labels = score_lbl_tensor_test[:, label_col].astype(int)
+    weights = score_lbl_tensor_test[:, weight_col]
+
+    true_classes = sorted(np.unique(labels).tolist())
+    print(f"Multi-class ROC: output nodes = {n_score}, true classes = {true_classes}")
+
+    roc_info_dict = {}
+
+    # --- One-vs-rest ROCs (overlaid on a single figure) ---
+    fig, ax = plt.subplots(figsize=[10, 8])
+    for out_idx in range(n_score):
+        scores = score_lbl_tensor_test[:, out_idx]
+        ovr_labels = (labels == out_idx).astype(int)
+        if ovr_labels.sum() == 0 or (1 - ovr_labels).sum() == 0:
+            continue
+
+        try:
+            fpr, tpr, _ = roc_curve(ovr_labels, scores, sample_weight=abs(weights))
+            roc_auc = roc_auc_score(ovr_labels, scores, sample_weight=abs(weights))
+        except ValueError as e:
+            print(f"Skipping one-vs-rest ROC for class {out_idx}: {e}")
+            continue
+
+        name = _class_label(class_info, out_idx, fallback=f"class {out_idx}")
+        ax.plot(tpr, fpr, label=f"{name} vs rest (AUC = {roc_auc:.3f})")
+        roc_info_dict[f"ovr_tpr_class_{out_idx}"] = tpr
+        roc_info_dict[f"ovr_fpr_class_{out_idx}"] = fpr
+        roc_info_dict[f"ovr_auc_class_{out_idx}"] = roc_auc
+
+    ax.set_xlabel("True positive rate")
+    ax.set_ylabel("False positive rate")
+    ax.set_yscale("log")
+    ax.legend(loc="upper left", fontsize="small")
+    ax.grid()
+    hep.cms.lumitext("2022 (13.6 TeV)", ax=ax)
+    hep.cms.text(text="Preliminary", ax=ax, loc=0)
+    if comet_logger:
+        comet_logger.log_figure("roc_curve_one_vs_rest", plt)
+    plt.savefig(f"{dir}/roc_curve_one_vs_rest.png", bbox_inches="tight", dpi=300)
+    plt.savefig(f"{dir}/roc_curve_one_vs_rest.pdf", bbox_inches="tight", dpi=300)
+    if show:
+        plt.show()
+    plt.close(fig)
+
+    # --- One-vs-one pairwise ROCs (overlaid) ---
+    fig, ax = plt.subplots(figsize=[10, 8])
+    for a, b in itertools.combinations(range(n_score), 2):
+        mask = (labels == a) | (labels == b)
+        if mask.sum() == 0:
+            continue
+        scores_a = score_lbl_tensor_test[mask, a]
+        sub_labels = (labels[mask] == a).astype(int)
+        sub_weights = weights[mask]
+        if sub_labels.sum() == 0 or (1 - sub_labels).sum() == 0:
+            continue
+
+        try:
+            fpr, tpr, _ = roc_curve(
+                sub_labels, scores_a, sample_weight=abs(sub_weights)
+            )
+            roc_auc = roc_auc_score(
+                sub_labels, scores_a, sample_weight=abs(sub_weights)
+            )
+        except ValueError as e:
+            print(f"Skipping pair {a} vs {b} ROC: {e}")
+            continue
+
+        a_name = _class_label(class_info, a, fallback=f"class {a}")
+        b_name = _class_label(class_info, b, fallback=f"class {b}")
+        ax.plot(
+            tpr, fpr, label=f"{a_name} vs {b_name} (AUC = {roc_auc:.3f})"
+        )
+        roc_info_dict[f"ovo_tpr_{a}_vs_{b}"] = tpr
+        roc_info_dict[f"ovo_fpr_{a}_vs_{b}"] = fpr
+        roc_info_dict[f"ovo_auc_{a}_vs_{b}"] = roc_auc
+
+    ax.set_xlabel("True positive rate")
+    ax.set_ylabel("False positive rate")
+    ax.set_yscale("log")
+    ax.legend(loc="upper left", fontsize="small")
+    ax.grid()
+    hep.cms.lumitext("2022 (13.6 TeV)", ax=ax)
+    hep.cms.text(text="Preliminary", ax=ax, loc=0)
+    if comet_logger:
+        comet_logger.log_figure("roc_curve_one_vs_one", plt)
+    plt.savefig(f"{dir}/roc_curve_one_vs_one.png", bbox_inches="tight", dpi=300)
+    plt.savefig(f"{dir}/roc_curve_one_vs_one.pdf", bbox_inches="tight", dpi=300)
+    if show:
+        plt.show()
+    plt.close(fig)
+
+    np.savez(f"{dir}/tpr_fpr_multiclass.npz", **roc_info_dict)
+
+
 def main():
     # parse the arguments
     parser = argparse.ArgumentParser()
@@ -694,6 +947,11 @@ def main():
     except KeyError:
         train_test_fractions = [0.8, 0.1]
 
+    try:
+        class_info = list(np.load(input_file, allow_pickle=True)["class_info"])
+    except KeyError:
+        class_info = None
+
     # plot the signal and background distributions
     plot_sig_bkg_distributions(
         score_lbl_tensor_train,
@@ -704,9 +962,12 @@ def main():
         train_test_fractions[1],
         signal_eff=args.signal_eff,
         get_max_significance=False,
+        class_info=class_info,
     )
 
-    plot_roc_curve(score_lbl_tensor_test, args.input_dir, args.show)
+    plot_roc_curve(
+        score_lbl_tensor_test, args.input_dir, args.show, class_info=class_info
+    )
 
 
 if __name__ == "__main__":

--- a/ml_pytorch/scripts/train.py
+++ b/ml_pytorch/scripts/train.py
@@ -204,6 +204,8 @@ def main():
         test_loader,
         input_size,
         batch_size,
+        num_classes,
+        class_info,
     ) = load_data(cfg, cfg.seed)
     
     if cfg.gpus is not None:
@@ -224,10 +226,32 @@ def main():
         logger=logger, patience=patience, min_delta=min_delta, eval_param=eval_param
     )
 
-    # Get model
-    model, loss_fn, optimizer, scheduler = ML_model.get_model(
-        input_size, device, cfg.learning_rate, cfg.learning_rate_schedule, n_epochs
-    )
+    # Get model. Multi-class capable models accept ``num_classes`` as an
+    # extra parameter; legacy binary models keep the original signature so
+    # we dispatch based on the function signature.
+    import inspect as _inspect
+
+    get_model_sig = _inspect.signature(ML_model.get_model)
+    if "num_classes" in get_model_sig.parameters:
+        model, loss_fn, optimizer, scheduler = ML_model.get_model(
+            input_size,
+            num_classes,
+            device,
+            cfg.learning_rate,
+            cfg.learning_rate_schedule,
+            n_epochs,
+        )
+    else:
+        if num_classes > 2:
+            raise ValueError(
+                f"Model {cfg.ML_model} does not support multi-class "
+                f"classification (num_classes={num_classes}). "
+                "Use a model whose get_model accepts a num_classes argument "
+                "(e.g. DNN_multiclass_model)."
+            )
+        model, loss_fn, optimizer, scheduler = ML_model.get_model(
+            input_size, device, cfg.learning_rate, cfg.learning_rate_schedule, n_epochs
+        )
     num_parameters = get_model_parameters_number(model)
 
     logger.info(f"Number of parameters: {num_parameters}")
@@ -478,6 +502,8 @@ def main():
                 score_lbl_array_train=score_lbl_array_train,
                 score_lbl_array_test=score_lbl_array_test,
                 train_test_fractions=train_test_fractions,
+                num_classes=np.array(num_classes),
+                class_info=np.array(class_info, dtype=object),
             )
             
         # plot the signal and background distributions
@@ -493,11 +519,18 @@ def main():
                 # [0.3363, 0.3937],
                 train_test_fractions[1],
                 comet_logger=comet_logger,
+                class_info=class_info,
             )
         if cfg.roc:
             logger.info("\n\n\n")
             logger.info("Plotting ROC curve")
-            plot_roc_curve(score_lbl_array_test, main_dir, False, comet_logger=comet_logger)
+            plot_roc_curve(
+                score_lbl_array_test,
+                main_dir,
+                False,
+                comet_logger=comet_logger,
+                class_info=class_info,
+            )
 
     # remove ML_model_loaded.py
     # if cfg.load_model or cfg.eval_model:

--- a/ml_pytorch/utils/dataset.py
+++ b/ml_pytorch/utils/dataset.py
@@ -18,6 +18,62 @@ logger = logging.getLogger(__name__)
 from ml_pytorch.defaults.preprocess_variables_functions import functions_dict
 
 
+def parse_classes(cfg):
+    """Normalize the two supported config layouts into a list of class
+    definitions.
+
+    Supported formats:
+      * New multiclass layout: ``cfg.classes`` is a mapping
+        ``{class_name: {sample, region, dataset, lbl}}``.
+      * Legacy binary layout: ``cfg.signal_*`` / ``cfg.background_*``.
+
+    Returns a list of dicts ordered by ``class_idx`` (0..C-1). Each dict has:
+      ``name``, ``samples``, ``datasets``, ``regions``, ``lbl`` (user label),
+      and ``class_idx`` (contiguous internal index used for training targets).
+    """
+    classes = []
+    if "classes" in cfg and cfg.classes is not None:
+        items = list(cfg.classes.items())
+        # sort by user-provided ``lbl`` so that the internal class_idx is
+        # deterministic regardless of dict iteration order
+        items.sort(key=lambda kv: kv[1].lbl)
+        for idx, (name, c) in enumerate(items):
+            classes.append(
+                {
+                    "name": name,
+                    "samples": list(c.sample),
+                    "datasets": list(c.dataset),
+                    "regions": list(c.region),
+                    "lbl": int(c.lbl),
+                    "class_idx": idx,
+                }
+            )
+    else:
+        # Legacy binary layout. Background first so it gets idx=0 and signal
+        # idx=1, matching the previous behaviour (sig label == 1, bkg == 0).
+        classes.append(
+            {
+                "name": "background",
+                "samples": list(cfg.background_sample),
+                "datasets": list(cfg.background_dataset),
+                "regions": list(cfg.background_region),
+                "lbl": 0,
+                "class_idx": 0,
+            }
+        )
+        classes.append(
+            {
+                "name": "signal",
+                "samples": list(cfg.signal_sample),
+                "datasets": list(cfg.signal_dataset),
+                "regions": list(cfg.signal_region),
+                "lbl": 1,
+                "class_idx": 1,
+            }
+        )
+    return classes
+
+
 def oversample_dataset(X_dataset):
 
     X_fts, X_lbl, X_clsw = X_dataset[:][0], X_dataset[:][1], X_dataset[:][2]
@@ -78,11 +134,16 @@ def get_variables(
     sample_list,
     dataset_list,
     region_list,
-    sig_bkg,
+    class_label,
     data_format,
     preprocess_variables_functions,
     novars=False,
 ):
+    """Load the input features and weights for a single class.
+
+    ``class_label`` is the integer used as the per-event target (typically the
+    internal class index 0..C-1).
+    """
     if data_format == "root":
         raise ValueError("Not updated for root format!")
         for i, file_name in enumerate(files):
@@ -455,12 +516,10 @@ def get_variables(
     tot_lenght = len(variables[0])
     logger.info(f"variables length {tot_lenght}")
 
-    logger.info(f"number of {sig_bkg} events: {variables.shape[1]}")
+    logger.info(f"number of events (class label {class_label}): {variables.shape[1]}")
 
-    flag_tensor = (
-        torch.ones_like(variables[0], dtype=torch.float32).unsqueeze(0)
-        if sig_bkg == "signal"
-        else torch.zeros_like(variables[0], dtype=torch.float32).unsqueeze(0)
+    flag_tensor = torch.full(
+        (1, variables.shape[1]), float(class_label), dtype=torch.float32
     )
 
     # shuffle the variables
@@ -475,6 +534,49 @@ def get_variables(
     return X, tot_lenght
 
 
+def _find_class_files(cfg, class_def):
+    """Return (coffea_files, parquet_dirs) for a given class definition."""
+    coffea_files = []
+    parquet_files = []
+
+    if cfg.data_format == "root":
+        for x in cfg.data_dirs:
+            files = os.listdir(x)
+            for file in files:
+                for sample in class_def["samples"]:
+                    if sample in file and "SR" in file:
+                        coffea_files.append(x + file)
+    elif cfg.data_format in ("coffea", "parquet"):
+        for direct in cfg.data_dirs:
+            if not os.path.isdir(direct):
+                raise FileNotFoundError(f"Data directory not found: {direct}")
+            for file in os.listdir(direct):
+                if file.endswith(".coffea"):
+                    if any(d in file for d in class_def["datasets"]):
+                        coffea_files.append(os.path.join(direct, file))
+
+        if cfg.data_format == "parquet":
+            for direct in cfg.data_dirs:
+                with open(f"{direct}/config.json", "r") as f:
+                    config = json.load(f)
+                parquet_dirs_path = root_to_local(
+                    config["workflow"]["workflow_options"]["save_chunk"]
+                )
+                if not os.path.isdir(parquet_dirs_path):
+                    raise FileNotFoundError(
+                        f"Local path not found on this node: {parquet_dirs_path}"
+                    )
+                for entry in os.scandir(parquet_dirs_path):
+                    logger.debug(f"Looking for files in {entry.path}")
+                    if entry.name in class_def["datasets"]:
+                        for region in class_def["regions"]:
+                            parquet_files.append(entry.path + "/" + region)
+    else:
+        raise ValueError(f"Data format {cfg.data_format} not supported")
+
+    return coffea_files, parquet_files
+
+
 def load_data(cfg, seed):
     batch_size = cfg.batch_size
     logger.debug(f"Batch size: {batch_size}")
@@ -482,111 +584,66 @@ def load_data(cfg, seed):
     # initialize numpy seed
     np.random.seed(int(seed))
 
-    dirs = cfg.data_dirs
-
     total_fraction_of_events = cfg.train_fraction + cfg.val_fraction + cfg.test_fraction
 
     assert total_fraction_of_events <= 1.0, "Fractions must sum to less than 1.0"
 
     logger.debug("Variables: %s", cfg.input_variables)
 
-    # list of signal and background files
-    sig_files = []
-    bkg_files = []
+    class_defs = parse_classes(cfg)
+    num_classes = len(class_defs)
+    logger.info(f"Number of classes: {num_classes}")
+    for c in class_defs:
+        logger.info(
+            f"  class idx={c['class_idx']} name={c['name']} lbl={c['lbl']} "
+            f"samples={c['samples']} datasets={c['datasets']} regions={c['regions']}"
+        )
 
-    sig_parquet_files = []
-    bkg_parquet_files = []
-
-    if cfg.data_format == "root":
-        for x in dirs:
-            files = os.listdir(x)
-            for file in files:
-                for signal in cfg.signal_sample:
-                    if signal in file and "SR" in file:
-                        sig_files.append(x + file)
-                for background in cfg.background_sample:
-                    if background in file and "SR" in file:
-                        bkg_files.append(x + file)
-    elif (cfg.data_format == "coffea") or (cfg.data_format == "parquet"):
-        for direct in dirs:
-            if not os.path.isdir(direct):
-                raise FileNotFoundError(f"Data directory not found: {direct}")
-            for file in os.listdir(direct):
-                if file.endswith(".coffea"):
-                    if any(signal in file for signal in cfg.signal_dataset):
-                        sig_files.append(os.path.join(direct, file))
-                    if any(background in file for background in cfg.background_dataset):
-                        bkg_files.append(os.path.join(direct, file))
-        logger.info(f"coffea sig files: {sig_files}")
-        logger.info(f"coffea bkg files: {bkg_files}")
-
+    # Load each class separately.
+    X_per_class = []
+    n_per_class = []
+    for c in class_defs:
+        coffea_files, parquet_files = _find_class_files(cfg, c)
+        logger.info(
+            f"Class {c['name']} (idx={c['class_idx']}): coffea files {coffea_files}"
+        )
         if cfg.data_format == "parquet":
-            for dir in dirs:
-                with open(f"{dir}/config.json", "r") as f:
-                    config = json.load(f)
-                parquet_dirs_path = root_to_local(
-                    config["workflow"]["workflow_options"]["save_chunk"]
-                )
-
-                if not os.path.isdir(parquet_dirs_path):
-                    raise FileNotFoundError(
-                        f"Local path not found on this node: {parquet_dirs_path}"
-                    )
-
-                for entry in os.scandir(parquet_dirs_path):
-                    logger.debug(f"Looking for files in {entry.path}")
-                    print(entry.name)
-                    if entry.name in cfg.signal_dataset:
-                        for region in cfg.signal_region:
-                            sig_parquet_files.append(entry.path + "/" + region)
-                    if entry.name in cfg.background_dataset:
-                        for region in cfg.background_region:
-                            bkg_parquet_files.append(entry.path + "/" + region)
-            logger.info(f"parquet sig files: {sig_parquet_files}")
-            logger.info(f"parquet bkg files: {bkg_parquet_files}")
-    else:
-        logger.error(f"Data format {cfg.data_format} not supported")
-        raise ValueError
-
-    logger.info(f"Signal files: {sig_files}")
-    logger.info(f"Background files: {bkg_files}")
-
-    X_sig, tot_lenght_sig = get_variables(
-        sig_files,
-        sig_parquet_files,
-        total_fraction_of_events,
-        cfg.input_variables,
-        cfg.signal_sample,
-        cfg.signal_dataset,
-        cfg.signal_region,
-        "signal",
-        cfg.data_format,
-        cfg.preprocess_variables_functions,
-        cfg.novars,
-    )
-    X_bkg, tot_lenght_bkg = get_variables(
-        bkg_files,
-        bkg_parquet_files,
-        total_fraction_of_events,
-        cfg.input_variables,
-        cfg.background_sample,
-        cfg.background_dataset,
-        cfg.background_region,
-        "background",
-        cfg.data_format,
-        cfg.preprocess_variables_functions,
-        cfg.novars,
-    )
-
-    # compute class weights such that sumw is the same for signal and background and each weight is order of 1
-
-    logger.info(f"Number of background events  {X_bkg[0].shape[1]}")
-    logger.info(f"Number of signal events {X_sig[0].shape[1]}")
+            logger.info(
+                f"Class {c['name']} (idx={c['class_idx']}): parquet files {parquet_files}"
+            )
+        X_class, n_class = get_variables(
+            coffea_files,
+            parquet_files,
+            total_fraction_of_events,
+            cfg.input_variables,
+            c["samples"],
+            c["datasets"],
+            c["regions"],
+            c["class_idx"],
+            cfg.data_format,
+            cfg.preprocess_variables_functions,
+            cfg.novars,
+        )
+        X_per_class.append(X_class)
+        n_per_class.append(n_class)
+        logger.info(f"Number of events for class {c['name']}: {n_class}")
 
     if cfg.oversample_split + cfg.split_oversample + cfg.undersample > 1:
         raise ValueError("Select only oversample or undersample")
 
-    if cfg.undersample:
+    # For binary backward compatibility, keep the legacy under/oversampling
+    # behaviour (signal/background). For multiclass we do not yet support these
+    # operations.
+    is_binary = num_classes == 2
+    if (cfg.undersample or cfg.oversample_split) and not is_binary:
+        raise ValueError(
+            "undersample and oversample_split are only supported for binary classification"
+        )
+
+    if cfg.undersample and is_binary:
+        # class_idx convention: 0=bkg, 1=signal
+        X_bkg = X_per_class[0]
+        X_sig = X_per_class[1]
         logger.info("Performing undersampling of background")
         logger.info(
             f"Number of background events before undersampling {X_bkg[0].shape[1]}"
@@ -595,108 +652,79 @@ def load_data(cfg, seed):
         X_bkg_f = X_bkg[0][:, :num_events_sig]
         X_bkg_l = X_bkg[1][:, :num_events_sig]
         X_bkg_k = X_bkg[2][:, :num_events_sig]
-        X_bkg = (X_bkg_f, X_bkg_l, X_bkg_k)
+        X_per_class[0] = (X_bkg_f, X_bkg_l, X_bkg_k)
         logger.info(
-            f"Number of background events after undersampling {X_bkg[0].shape[1]}"
+            f"Number of background events after undersampling {X_per_class[0][0].shape[1]}"
         )
 
-    if cfg.oversample_split:
+    if cfg.oversample_split and is_binary:
+        X_bkg = X_per_class[0]
+        X_sig = X_per_class[1]
         logger.info("Performing oversampling of signal before splitting")
         num_events_sig = X_sig[0].shape[1]
         num_events_bkg = X_bkg[0].shape[1]
-        X_sig_f = X_sig[0].repeat((1, num_events_bkg // num_events_sig + 1))[
-            :, :num_events_bkg
-        ]
-        X_sig_l = X_sig[1].repeat((1, num_events_bkg // num_events_sig + 1))[
-            :, :num_events_bkg
-        ]
-        X_sig_k = X_sig[2].repeat((1, num_events_bkg // num_events_sig + 1))[
-            :, :num_events_bkg
-        ]
-        X_sig = (X_sig_f, X_sig_l, X_sig_k)
-
+        repeat = num_events_bkg // num_events_sig + 1
+        X_sig_f = X_sig[0].repeat((1, repeat))[:, :num_events_bkg]
+        X_sig_l = X_sig[1].repeat((1, repeat))[:, :num_events_bkg]
+        X_sig_k = X_sig[2].repeat((1, repeat))[:, :num_events_bkg]
+        X_per_class[1] = (X_sig_f, X_sig_l, X_sig_k)
         if num_events_sig > num_events_bkg:
             raise ValueError(
-                "Number of signal events is greater than number of background events. This will be fixed in the oversampling function"
+                "Number of signal events is greater than number of background events."
             )
+        logger.info(
+            f"Number of signal events after oversampling {X_per_class[1][0].shape[1]}"
+        )
 
-        logger.info(f"Number of signal events after oversampling {X_sig[0].shape[1]}")
-
-    num_events_bkg = X_bkg[0].shape[1]
-    num_events_sig = X_sig[0].shape[1]
-
-    # sum of weights
-    sumw_sig = X_sig[0][-1].sum()
-    sumw_bkg = X_bkg[0][-1].sum()
-    logger.info(f"sum of weights before rescaling signal: {sumw_sig}")
-    logger.info(f"sum of weights before rescaling backgound: {sumw_bkg}")
+    # Compute per-class weights so that the sum of weights is the same across
+    # all classes (and per-class sum equals N / num_classes). This generalises
+    # the previous binary balancing formula
+    # ``(n_sig + n_bkg) / (2 * sumw_class)`` to arbitrary number of classes.
+    n_per_class = [X[0].shape[1] for X in X_per_class]
+    n_total = sum(n_per_class)
+    sumw_per_class = [float(X[0][-1].sum()) for X in X_per_class]
+    for c, n, sumw in zip(class_defs, n_per_class, sumw_per_class):
+        logger.info(
+            f"Class {c['name']} (idx={c['class_idx']}): n_events={n}, sum_weights={sumw}"
+        )
 
     if not cfg.oversample_split and not cfg.split_oversample and not cfg.undersample:
-        if True:
-            sig_class_weights = (num_events_sig + num_events_bkg) / (2 * sumw_sig)
-            bkg_class_weights = (num_events_sig + num_events_bkg) / (2 * sumw_bkg)
-        else:
-            # Compute the effective class count
-            # https://arxiv.org/pdf/1901.05555.pdf
-
-            sig_event_weights = X_sig[0][-1]
-            beta_sig = 1 - (1 / sig_event_weights.sum())
-            sig_class_weights = (1 - beta_sig) / (1 - beta_sig**num_events_sig)
-
-            logger.info(
-                f"num event sig {num_events_sig}, sig_event_weights {sig_event_weights.sum()}, beta_sig {beta_sig}, sig_class_weights {sig_class_weights}"
-            )
-
-            bkg_event_weights = X_bkg[0][-1]
-            beta_bkg = 1 - (1 / bkg_event_weights.sum())
-            bkg_class_weights = (1 - beta_bkg) / (1 - beta_bkg**num_events_bkg)
-
-            logger.info(
-                f"num event bkg {num_events_bkg}, bkg_event_weights {bkg_event_weights.sum()}, beta_bkg {beta_bkg}, bkg_class_weights {bkg_class_weights}"
-            )
+        class_weights = [n_total / (num_classes * sw) for sw in sumw_per_class]
     else:
-        sig_class_weights = 1.0
-        bkg_class_weights = 1.0
+        class_weights = [1.0 for _ in range(num_classes)]
 
-    rescaled_sig_weights = X_sig[0][-1] * sig_class_weights
-    rescaled_bkg_weights = X_bkg[0][-1] * bkg_class_weights
+    for c, cw in zip(class_defs, class_weights):
+        logger.info(f"Class {c['name']} class_weight: {cw}")
 
-    logger.info(f"sig_class_weights: {sig_class_weights}")
-    logger.info(f"bkg_class_weights: {bkg_class_weights}")
+    # Per-event class-weight tensors, ready for concatenation.
+    clsw_tensors = [
+        (torch.ones_like(X[0][-1], dtype=torch.float32) * w).unsqueeze(0)
+        for X, w in zip(X_per_class, class_weights)
+    ]
+    for c, X, w in zip(class_defs, X_per_class, class_weights):
+        rescaled = X[0][-1] * w
+        logger.info(
+            f"Class {c['name']} sum of weights after rescaling: {float(rescaled.sum())}"
+        )
 
-    # sum of weights
-    sumw_sig = rescaled_sig_weights.sum()
-    sumw_bkg = rescaled_bkg_weights.sum()
-    logger.info(f"sum of weights after rescaling signal: {sumw_sig}")
-    logger.info(f"sum of weights after rescaling backgound: {sumw_bkg}")
-
-    sig_class_weights_tensor = (
-        torch.ones_like(X_sig[0][-1], dtype=torch.float32) * sig_class_weights
-    ).unsqueeze(0)
-    bkg_class_weights_tensor = (
-        torch.ones_like(X_bkg[0][-1], dtype=torch.float32) * bkg_class_weights
-    ).unsqueeze(0)
-
-    X_fts = torch.cat((X_sig[0], X_bkg[0]), dim=1).transpose(1, 0)
-    X_lbl = torch.cat((X_sig[1], X_bkg[1]), dim=1).transpose(1, 0).flatten()
-    X_clsw = torch.cat(
-        (sig_class_weights_tensor, bkg_class_weights_tensor), dim=1
-    ).transpose(1, 0)
-    X_k = torch.cat((X_sig[2], X_bkg[2]), dim=1).transpose(1, 0).flatten()
+    X_fts = torch.cat([X[0] for X in X_per_class], dim=1).transpose(1, 0)
+    X_lbl = torch.cat([X[1] for X in X_per_class], dim=1).transpose(1, 0).flatten()
+    X_clsw = torch.cat(clsw_tensors, dim=1).transpose(1, 0)
+    X_k = torch.cat([X[2] for X in X_per_class], dim=1).transpose(1, 0).flatten()
 
     logger.info(f"X_fts shape: {X_fts.shape}")
     logger.info(f"X_lbl shape: {X_lbl.shape}")
     logger.info(f"X_clsw shape: {X_clsw.shape}")
     logger.info(f"X_k shape: {X_k.shape}")
 
-    tot_num_events = num_events_sig + num_events_bkg
-    if True:
-        # shuffle the tensor with numpy random
-        idx = np.random.permutation(tot_num_events)
-        X_fts = X_fts[idx]
-        X_lbl = X_lbl[idx]
-        X_clsw = X_clsw[idx]
-        X_k = X_k[idx]
+    tot_num_events = X_fts.shape[0]
+
+    # shuffle the tensor with numpy random
+    idx = np.random.permutation(tot_num_events)
+    X_fts = X_fts[idx]
+    X_lbl = X_lbl[idx]
+    X_clsw = X_clsw[idx]
+    X_k = X_k[idx]
 
     train_size = math.floor(tot_num_events * cfg.train_fraction)
     val_size = math.floor(tot_num_events * cfg.val_fraction)
@@ -725,7 +753,10 @@ def load_data(cfg, seed):
     )
 
     if cfg.split_oversample:
-        # perform the oversampling of the signal separately for training, validation and testing datasets
+        if not is_binary:
+            raise ValueError(
+                "split_oversample is only supported for binary classification"
+            )
         logger.info("Performing oversampling of signal after splitting")
         train_dataset = oversample_dataset(train_dataset)
         val_dataset = oversample_dataset(val_dataset)
@@ -770,12 +801,19 @@ def load_data(cfg, seed):
     # remove 1 because of the weights
     input_size = X_fts.size(1) - 1
 
+    class_info = [
+        {"name": c["name"], "lbl": c["lbl"], "class_idx": c["class_idx"]}
+        for c in class_defs
+    ]
+
     return (
         training_loader,
         val_loader,
         test_loader,
         input_size,
         batch_size,
+        num_classes,
+        class_info,
     )
 
 

--- a/ml_pytorch/utils/tools.py
+++ b/ml_pytorch/utils/tools.py
@@ -393,23 +393,29 @@ def eval_model(model, loader, loss_fn, type_eval, device, best_epoch):
     avg_loss = tot_loss / len(loader)
     avg_accuracy = tot_correct / tot_num
 
+    # Normalize raw logits into probabilities so that the saved scores live
+    # in [0, 1] regardless of the model architecture.
     if torch.any(all_scores < 0) or torch.any(all_scores > 1):
-        if all_scores.shape[1] == 2:
-            all_scores = torch.nn.functional.softmax(all_scores, dim=1)
-        elif all_scores.shape[1] == 1:
+        if all_scores.shape[1] == 1:
             all_scores = torch.nn.functional.sigmoid(all_scores)
-    if all_scores.shape[1] == 2:
-        all_scores = all_scores[:, -1]
-    elif all_scores.shape[1] > 2:
-        raise ValueError("The number of output nodes is not 1 or 2")
+        else:
+            all_scores = torch.nn.functional.softmax(all_scores, dim=1)
 
-    # concatenate all scores and labels
-    all_scores = all_scores.view(-1, 1)
+    # For backward compatibility with the binary sig/bkg case (1 or 2 output
+    # nodes) we collapse to a single column containing the signal probability.
+    # For genuine multi-class outputs (>=3) we keep all class probabilities.
+    if all_scores.shape[1] == 2:
+        all_scores = all_scores[:, -1].view(-1, 1)
+    elif all_scores.shape[1] == 1:
+        all_scores = all_scores.view(-1, 1)
+
     all_labels = all_labels.view(-1, 1)
     all_weights = all_weights.view(-1, 1)
     all_kl_values = all_kl_values.view(-1, 1)
 
-    score_lbl_tensor = torch.cat((all_scores, all_labels, all_weights, all_kl_values), 1)
+    score_lbl_tensor = torch.cat(
+        (all_scores, all_labels, all_weights, all_kl_values), 1
+    )
     logger.info(f"score_lbl_tensor shape: {score_lbl_tensor.shape}")
 
     # detach the tensor from the graph and convert to numpy array


### PR DESCRIPTION
## Summary

Adds support for multi-class classification while keeping the legacy binary `signal_*`/`background_*` YAML layout fully backward compatible. The new config layout uses a `classes` block where each entry defines one output class:

```yaml
classes:
  classA:
    sample: [...]
    region: [...]
    dataset: [...]
    lbl: 1
  classB:
    sample: [...]
    region: [...]
    dataset: [...]
    lbl: 2
  classC:
    sample: [...]
    region: [...]
    dataset: [...]
    lbl: 3
```

The old binary layout still works without any changes.

## What changed

- **`ml_pytorch/utils/dataset.py`** — new `parse_classes(cfg)` normalises both formats into a list of class definitions. `load_data` loops over the classes, computes generalised class weights `n_total / (C * sum_w_c)`, and stores the **internal class index** (`0..C-1`) as the per-event target so `CrossEntropyLoss` works directly. `load_data` now also returns `num_classes` and a `class_info` list. The legacy `undersample` / `oversample_split` / `split_oversample` operations remain available, restricted to the binary case (signal index 1, background index 0).
- **`ml_pytorch/utils/tools.py`** — `eval_model` now keeps the full `[N, C]` softmax output when the model has more than two output nodes. The binary case (1 sigmoid output or 2 softmax outputs) still collapses to a single score column, so existing `score_lbl_array.npz` files remain unchanged.
- **`ml_pytorch/scripts/train.py`** — uses `inspect.signature` to dispatch: if `get_model` accepts `num_classes` (the new multiclass model) it is passed, otherwise the legacy signature is used. The class metadata (`num_classes`, `class_info`) is now saved to `score_lbl_array.npz`. A clear error is raised if a legacy binary model is paired with `num_classes > 2`.
- **`ml_pytorch/models/DNN_multiclass_model.py`** — new model with a softmax head whose size is driven by `num_classes` (matching the architecture sketch in the task description).
- **`ml_pytorch/scripts/sig_bkg_eval.py`** — column indices are now computed from the array layout (the last three columns are always `[label, weight, kl]`). When the script detects more than one score column it dispatches to two new plotters:
  - `plot_multiclass_distributions`: per-output-node score distribution, split by true class (linear + log).
  - `plot_multiclass_roc_curves`: one-vs-rest ROC for every class and one-vs-one pairwise ROC for every class pair. AUCs are saved into `tpr_fpr_multiclass.npz`.
  
  The binary path is unchanged.
- **`configs/hh4b_sig_bkg_classifier/example_DNN_config_multiclass.yml`** — example 3-class config (background / ggF HH / VBF HH) showing the new layout.

## Test plan

- [x] Synthetic-data smoke test on multi-class path: `load_data` → `DNN_multiclass_model` → one training epoch → `eval_model` produces `score_lbl_array` of shape `(N, C+3)`.
- [x] Synthetic-data smoke test on legacy binary path with `DNN_softmax_reweight_model`: `score_lbl_array` shape unchanged at `(N, 4)`.
- [x] Plot smoke test on fake 3-class scores: generates `roc_curve_one_vs_rest.{png,pdf}`, `roc_curve_one_vs_one.{png,pdf}`, `score_distribution_class_{0,1,2}.{png,pdf}`, `tpr_fpr_multiclass.npz`.
- [x] Plot smoke test on fake binary scores: existing `roc_curve_kl_*` and `sig_bkg_distributions_kl_*` outputs are still produced.
- [ ] End-to-end training on a real multi-class dataset (e.g. signal + multiple background classes) to confirm convergence and inspect ROCs/distributions.

https://claude.ai/code/session_019kP2N4nSqsWVQH3ceffZ12

---
_Generated by [Claude Code](https://claude.ai/code/session_019kP2N4nSqsWVQH3ceffZ12)_